### PR TITLE
Add Imperial and UsCustomary units for Length and Area

### DIFF
--- a/src/Data/Units/Imperial.hs
+++ b/src/Data/Units/Imperial.hs
@@ -1,0 +1,6 @@
+module Data.Units.Imperial
+  (module Data.Units.Imperial.Length
+  ) where
+
+import Data.Units.Imperial.Length
+

--- a/src/Data/Units/Imperial/Area.hs
+++ b/src/Data/Units/Imperial/Area.hs
@@ -1,0 +1,20 @@
+module Data.Units.Imperial.Area
+  ( Acre(..)
+  , Perch(..)
+  , Rood(..)
+  ) where
+
+import Data.Units.Base
+import Data.Units.SI
+
+-- | Area in acres.
+--
+$(mkUnit "Acre" "ac" ''Area $ (1200 / 3937)^2 * 43560)
+
+-- | Area in perches.
+--
+$(mkUnit "Perch" "perch" ''Area $ (1200 / 3937)^2 * 1089 / 4)
+
+-- | Area in roods.
+--
+$(mkUnit "Rood" "ro" ''Area $ (1200 / 3937)^2 * 10890)

--- a/src/Data/Units/Imperial/Length.hs
+++ b/src/Data/Units/Imperial/Length.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Data.Units.Imperial.Length
+  ( Twip(..)
+  , Thou(..)
+  , Barleycorn(..)
+  , Inch(..)
+  , Hand(..)
+  , Foot(..)
+  , Yard(..)
+  , Chain(..)
+  , Furlong(..)
+  , Mile(..)
+  , League(..)
+  , Fathom(..)
+  , Cable(..)
+  , NauticalMile(..)
+  , Link(..)
+  , Rod(..)
+  ) where
+
+import Data.Units.Base
+import Data.Units.SI
+
+
+-- | Length in feet.
+$(mkUnit "Foot" "ft" ''Length $ 1200 / 3937)
+
+-- | Length in twips.
+$(mkUnit "Twip" "twip" ''Length $ 1200 / 3937 / 17280)
+
+-- | Length in thous.
+$(mkUnit "Thou" "th" ''Length $ 1200 / 3937 / 12000)
+
+-- | Length in barleycorns.
+$(mkUnit "Barleycorn" "barleycorn" ''Length $ 1200 / 3937 / 36)
+
+-- | Length in inches.
+$(mkUnit "Inch" "in" ''Length $ 1200 / 3937 / 12)
+
+-- | Length in hands.
+$(mkUnit "Hand" "hh" ''Length $ 1200 / 3937 / 3)
+
+-- | Length in yards.
+$(mkUnit "Yard" "yd" ''Length $ 1200 / 3937 * 3)
+
+-- | Length in chains.
+$(mkUnit "Chain" "ch" ''Length $ 1200 / 3937 * 66)
+
+-- | Length in furlongs.
+$(mkUnit "Furlong" "fur" ''Length $ 1200 / 3937 * 660)
+
+-- | Length in miles.
+$(mkUnit "Mile" "mi" ''Length $ 1200 / 3937 * 5280)
+
+-- | Length in leagues.
+$(mkUnit "League" "lea" ''Length $ 1200 / 3937 * 15840)
+
+-- | Length in fathoms.
+$(mkUnit "Fathom" "ftm" ''Length $ 1200 / 3937 * 6.0761)
+
+-- | Length in cables.
+$(mkUnit "Cable" "cable" ''Length $ 1200 / 3937 * 607.61)
+
+-- | Length in nautical miles.
+$(mkUnit "NauticalMile" "nmi" ''Length $ 1200 / 3937 * 60761 / 10)
+
+-- | Length in links.
+$(mkUnit "Link" "lnk" ''Length $ 1200 / 3937 * 66 / 100)
+
+-- | Length in rods.
+$(mkUnit "Rod" "rod" ''Length $ 1200 / 3937 * 66 / 4)

--- a/src/Data/Units/NonStd/Area.hs
+++ b/src/Data/Units/NonStd/Area.hs
@@ -1,0 +1,7 @@
+module Data.Units.NonStd.Area
+  ( module Data.Units.Imperial.Area
+  , module Data.Units.UsCustomary.Area
+  ) where
+
+import Data.Units.Imperial.Area
+import Data.Units.UsCustomary.Area

--- a/src/Data/Units/NonStd/Length.hs
+++ b/src/Data/Units/NonStd/Length.hs
@@ -1,0 +1,7 @@
+module Data.Units.NonStd.Length
+  ( module Data.Units.UsCustomary.Length
+  , module Data.Units.Imperial.Length
+  ) where
+
+import Data.Units.UsCustomary.Length
+import Data.Units.Imperial.Length

--- a/src/Data/Units/UsCustomary.hs
+++ b/src/Data/Units/UsCustomary.hs
@@ -1,0 +1,5 @@
+module Data.Units.UsCustomary
+  ( module Data.Units.UsCustomary.Length
+  ) where
+
+import Data.Units.UsCustomary.Length

--- a/src/Data/Units/UsCustomary/Area.hs
+++ b/src/Data/Units/UsCustomary/Area.hs
@@ -1,0 +1,5 @@
+module Data.Units.UsCustomary.Area
+  ( Acre(..)
+  ) where
+
+import Data.Units.Imperial.Area (Acre(..))

--- a/src/Data/Units/UsCustomary/Length.hs
+++ b/src/Data/Units/UsCustomary/Length.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Data.Units.UsCustomary.Length
+-- Reexport the imperial units that are also used in US customary within the US
+-- customary modules
+  ( Mil
+  , Point
+  , Pica
+  , Data.Units.Imperial.Length.Twip
+  , Data.Units.Imperial.Length.Inch
+  , Data.Units.Imperial.Length.Foot
+  , Data.Units.Imperial.Length.Yard
+  , Data.Units.Imperial.Length.Mile
+  , Data.Units.Imperial.Length.League
+  , Data.Units.Imperial.Length.Fathom
+  , Data.Units.Imperial.Length.Cable
+  , Data.Units.Imperial.Length.NauticalMile
+  ) where
+
+import Data.Units.Base
+import Data.Units.SI
+import Data.Units.Imperial.Length
+
+
+-- | Length in mils.
+$(mkUnit "Mil" "mil" ''Length $ 1200 / 3937 / 12 / 1000)
+
+-- | Length in points.
+$(mkUnit "Point" "p" ''Length $ 1200 / 3937 / 12 / 72)
+
+-- | Length in picas.
+$(mkUnit "Pica" "P" ''Length $ 1200 / 3937 / 12 / 72 * 12)

--- a/test/Data/Units/NonStd/AreaSpec.hs
+++ b/test/Data/Units/NonStd/AreaSpec.hs
@@ -1,0 +1,25 @@
+module Data.Units.NonStd.AreaSpec where
+
+import Test.Hspec
+
+import Data.Units.Base.ConvertProp
+import Data.Units.Base.System
+import Data.Units.Imperial.Area
+import Data.Units.SI
+
+type SquareMeter = (Meter .^+ 2) Double
+
+spec :: Spec
+spec = do
+  describe "Area" $ do
+    toFromSpec @Acre    @Double
+    fromToAssert @Double (1 :: SquareMeter) (Acre $ 1 / ((1200 / 3937)^2 * 43560))
+    fromToAssert @Double (Acre 1) ((1200 / 3937)^2 * 43560 :: SquareMeter)
+
+    toFromSpec @Perch    @Double
+    fromToAssert @Double (1 :: SquareMeter) (Perch $ 1 / ((1200 / 3937)^2 * 1089 / 4))
+    fromToAssert @Double (Perch 1) ((1200 / 3937)^2 * 1089 / 4 :: SquareMeter)
+
+    toFromSpec @Rood    @Double
+    fromToAssert @Double (1 :: SquareMeter) (Rood $ 1 / ((1200 / 3937)^2 * 10890))
+    fromToAssert @Double (Rood 1) ((1200 / 3937)^2 * 10890 :: SquareMeter)

--- a/test/Data/Units/NonStd/LengthSpec.hs
+++ b/test/Data/Units/NonStd/LengthSpec.hs
@@ -1,0 +1,131 @@
+module Data.Units.NonStd.LengthSpec where
+
+import Test.Hspec
+
+import Data.Units.NonStd.Length
+import Data.Units.SI
+
+import Data.Units.Base.ConvertProp
+
+spec :: Spec
+spec = do
+  describe "Length" $ do
+    toFromSpec @Foot    @Double
+    fromToAssert @Double (Meter 1) (Foot $ 1 / (1200 / 3937))
+    fromToAssert @Double (Foot 1) (Meter $ 1200 / 3937)
+
+    toFromSpec @Twip    @Double
+    fromToAssert @Double (Meter 1) (Twip $ 1 / (1200 / 3937 / 17280))
+    fromToAssert @Double (Twip 1) (Meter $ 1200 / 3937 / 17280)
+
+    toFromSpec @Thou    @Double
+    fromToAssert @Double (Meter 1) (Thou $ 1 / (1200 / 3937 / 12000))
+    fromToAssert @Double (Thou 1) (Meter $ 1200 / 3937 / 12000)
+
+    toFromSpec @Barleycorn    @Double
+    fromToAssert @Double (Meter 1) (Barleycorn $ 1 / (1200 / 3937 / 36))
+    fromToAssert @Double (Barleycorn 1) (Meter $ 1200 / 3937 / 36)
+
+    toFromSpec @Inch    @Double
+    fromToAssert @Double (Meter 1) (Inch $ 1 / (1200 / 3937 / 12))
+    fromToAssert @Double (Inch 1) (Meter $ 1200 / 3937 / 12)
+
+    toFromSpec @Hand    @Double
+    fromToAssert @Double (Meter 1) (Hand $ 1 / (1200 / 3937 / 3))
+    fromToAssert @Double (Hand 1) (Meter $ 1200 / 3937 / 3)
+
+    toFromSpec @Yard    @Double
+    fromToAssert @Double (Meter 1) (Yard $ 1 / (1200 / 3937 * 3))
+    fromToAssert @Double (Yard 1) (Meter $ 1200 / 3937 * 3)
+
+    toFromSpec @Chain    @Double
+    fromToAssert @Double (Meter 1) (Chain $ 1 / (1200 / 3937 * 66))
+    fromToAssert @Double (Chain 1) (Meter $ 1200 / 3937 * 66)
+
+    toFromSpec @Furlong    @Double
+    fromToAssert @Double (Meter 1) (Furlong $ 1 / (1200 / 3937 * 660))
+    fromToAssert @Double (Furlong 1) (Meter $ 1200 / 3937 * 660)
+
+    toFromSpec @Mile    @Double
+    fromToAssert @Double (Meter 1) (Mile $ 1 / (1200 / 3937 * 5280))
+    fromToAssert @Double (Mile 1) (Meter $ 1200 / 3937 * 5280)
+
+    toFromSpec @League    @Double
+    fromToAssert @Double (Meter 1) (League $ 1 / (1200 / 3937 * 15840))
+    fromToAssert @Double (League 1) (Meter $ 1200 / 3937 * 15840)
+
+    toFromSpec @Fathom    @Double
+    fromToAssert @Double (Meter 1) (Fathom $ 1 / (1200 / 3937 * 6.0761))
+    fromToAssert @Double (Fathom 1) (Meter $ 1200 / 3937 * 6.0761)
+
+    toFromSpec @Cable    @Double
+    fromToAssert @Double (Meter 1) (Cable $ 1 / (1200 / 3937 * 607.61))
+    fromToAssert @Double (Cable 1) (Meter $ 1200 / 3937 * 607.61)
+
+    toFromSpec @NauticalMile    @Double
+    fromToAssert @Double (Meter 1) (NauticalMile $ 1 / (1200 / 3937 * 60761 / 10))
+    fromToAssert @Double (NauticalMile 1) (Meter $ 1200 / 3937 * 60761 / 10)
+
+    toFromSpec @Link    @Double
+    fromToAssert @Double (Meter 1) (Link $ 1 / (1200 / 3937 * 66 / 100))
+    fromToAssert @Double (Link 1) (Meter $ 1200 / 3937 * 66 / 100)
+
+    toFromSpec @Rod    @Double
+    fromToAssert @Double (Meter 1) (Rod $ 1 / (1200 / 3937 * 66 / 4))
+    fromToAssert @Double (Rod 1) (Meter $ 1200 / 3937 * 66 / 4)
+
+    toFromSpec @Thou    @Double
+    fromToAssert @Double (Meter 1) (Thou $ 1 / (1200 / 3937 / 12000))
+    fromToAssert @Double (Thou 1) (Meter $ 1200 / 3937 / 12000)
+
+    toFromSpec @Barleycorn    @Double
+    fromToAssert @Double (Meter 1) (Barleycorn $ 1 / (1200 / 3937 / 36))
+    fromToAssert @Double (Barleycorn 1) (Meter $ 1200 / 3937 / 36)
+
+    toFromSpec @Inch    @Double
+    fromToAssert @Double (Meter 1) (Inch $ 1 / (1200 / 3937 / 12))
+    fromToAssert @Double (Inch 1) (Meter $ 1200 / 3937 / 12)
+
+    toFromSpec @Hand    @Double
+    fromToAssert @Double (Meter 1) (Hand $ 1 / (1200 / 3937 / 3))
+    fromToAssert @Double (Hand 1) (Meter $ 1200 / 3937 / 3)
+
+    toFromSpec @Yard    @Double
+    fromToAssert @Double (Meter 1) (Yard $ 1 / (1200 / 3937 * 3))
+    fromToAssert @Double (Yard 1) (Meter $ 1200 / 3937 * 3)
+
+    toFromSpec @Chain    @Double
+    fromToAssert @Double (Meter 1) (Chain $ 1 / (1200 / 3937 * 66))
+    fromToAssert @Double (Chain 1) (Meter $ 1200 / 3937 * 66)
+
+    toFromSpec @Furlong    @Double
+    fromToAssert @Double (Meter 1) (Furlong $ 1 / (1200 / 3937 * 660))
+    fromToAssert @Double (Furlong 1) (Meter $ 1200 / 3937 * 660)
+
+    toFromSpec @Mile    @Double
+    fromToAssert @Double (Meter 1) (Mile $ 1 / (1200 / 3937 * 5280))
+    fromToAssert @Double (Mile 1) (Meter $ 1200 / 3937 * 5280)
+
+    toFromSpec @League    @Double
+    fromToAssert @Double (Meter 1) (League $ 1 / (1200 / 3937 * 15840))
+    fromToAssert @Double (League 1) (Meter $ 1200 / 3937 * 15840)
+
+    toFromSpec @Fathom    @Double
+    fromToAssert @Double (Meter 1) (Fathom $ 1 / (1200 / 3937 * 6.0761))
+    fromToAssert @Double (Fathom 1) (Meter $ 1200 / 3937 * 6.0761)
+
+    toFromSpec @Cable    @Double
+    fromToAssert @Double (Meter 1) (Cable $ 1 / (1200 / 3937 * 607.61))
+    fromToAssert @Double (Cable 1) (Meter $ 1200 / 3937 * 607.61)
+
+    toFromSpec @NauticalMile    @Double
+    fromToAssert @Double (Meter 1) (NauticalMile $ 1 / (1200 / 3937 * 60761 / 10))
+    fromToAssert @Double (NauticalMile 1) (Meter $ 1200 / 3937 * 60761 / 10)
+
+    toFromSpec @Link    @Double
+    fromToAssert @Double (Meter 1) (Link $ 1 / (1200 / 3937 * 66 / 100))
+    fromToAssert @Double (Link 1) (Meter $ 1200 / 3937 * 66 / 100)
+
+    toFromSpec @Rod    @Double
+    fromToAssert @Double (Meter 1) (Rod $ 1 / (1200 / 3937 * 66 / 4))
+    fromToAssert @Double (Rod 1) (Meter $ 1200 / 3937 * 66 / 4)


### PR DESCRIPTION
Hi there. I found this project on [Haskell Weekly](https://haskellweekly.news/issue/489.html).

Is #3 expecting something like this?

I don't really understand the dir structure... As in, what's the relation between the line `$(mkUnitNoFactor "Celsius" "°C" ''Temperature)` which is about temperature in Celsious degree, and the path `Data/Units/SI/Derived/NonAngle.hs` of the file that contains it? How is "temperature in celsius" an "SI derived non-angle unit"? I mean, every unit is a non-angle unit if it... a non-angle unit.